### PR TITLE
Remove nullable type for PHP >=7.0 support

### DIFF
--- a/src/JWKConverter.php
+++ b/src/JWKConverter.php
@@ -22,7 +22,7 @@ class JWKConverter
     /** @var Base64UrlDecoder */
     private $base64UrlDecoder;
 
-    public function __construct(?Base64UrlDecoder $base64UrlDecoder = null)
+    public function __construct(Base64UrlDecoder $base64UrlDecoder = null)
     {
         $this->base64UrlDecoder = $base64UrlDecoder ?? new Base64UrlDecoder();
     }


### PR DESCRIPTION
The composer.json file for this package specifies `"php": ">=7.0.0",` as a requirement.

Nullable types were introduced in 7.1