### PR TITLE
Added support for converting multiple JWKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ BwIDAQAB\r\n
 -----END PUBLIC KEY-----
 ```
 
+You can also convert multiple JWKs by using `multipleToPem`:
+
+``` php
+$keys = $jwkConverter->multipleToPEM($jwkSet);
+// $keys now contains an array of PEMs
+```
+
+
 ## License
 
 [MIT](LICENSE)

--- a/src/JWKConverter.php
+++ b/src/JWKConverter.php
@@ -75,7 +75,7 @@ class JWKConverter
                 'n' => new BigInteger($this->base64UrlDecoder->decode($jwk['n']), 256)
             ]
         );
-        die($rsa->getPublicKey());
+        
         return $rsa->getPublicKey();
     }
 

--- a/src/JWKConverter.php
+++ b/src/JWKConverter.php
@@ -28,6 +28,27 @@ class JWKConverter
     }
 
     /**
+     * @param array $jwkSet
+     * @return string[]
+     * @throws JWKConverterException
+     * @throws Exception\Base64DecodeException
+     */
+    public function multipleToPem(array $jwkSet): array
+    {
+        $keys = [];
+
+        foreach($jwkSet as $jwk) {
+            if(!is_array($jwk)) {
+                throw new JWKConverterException('`multipleToPem` can only take in an array of JWKs.');
+            }
+
+            $keys[] = $this->toPEM($jwk);
+        }
+
+        return $keys;
+    }
+
+    /**
      * @param array $jwk
      * @return string
      * @throws Exception\Base64DecodeException
@@ -54,6 +75,7 @@ class JWKConverter
                 'n' => new BigInteger($this->base64UrlDecoder->decode($jwk['n']), 256)
             ]
         );
+        die($rsa->getPublicKey());
         return $rsa->getPublicKey();
     }
 

--- a/tests/JWKConverterTest.php
+++ b/tests/JWKConverterTest.php
@@ -15,6 +15,76 @@ class JWKConverterTest extends TestCase
         $this->jwkConverter = new JwkConverter();
     }
 
+    /** @dataProvider provideMultipleToPem */
+    public function testMultipleToPem($jwkSet, $expected)
+    {
+        print_r($this->jwkConverter->multipleToPem($jwkSet));
+        $this->assertEquals($expected, $this->jwkConverter->multipleToPem($jwkSet));
+    }
+
+    public function provideMultipleToPem()
+    {
+        return [
+            [
+                [
+                    [
+                        'kty' => 'RSA',
+                        'kid' => '86D88Kf',
+                        'use' => 'sig',
+                        'alg' => 'RS256',
+                        'n' => 'iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ',
+                        'e' => 'AQAB',
+                    ],
+                    [
+                        'kty' => 'RSA',
+                        'kid' => 'eXaunmL',
+                        'use' => 'sig',
+                        'alg' => 'RS256',
+                        'n' => '4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw',
+                        'e' => 'AQAB',
+                    ],
+                    [
+                        'kty' => 'RSA',
+                        'kid' => 'AIDOPK1',
+                        'use' => 'sig',
+                        'alg' => 'RS256',
+                        'n' => 'lxrwmuYSAsTfn-lUu4goZSXBD9ackM9OJuwUVQHmbZo6GW4Fu_auUdN5zI7Y1dEDfgt7m7QXWbHuMD01HLnD4eRtY-RNwCWdjNfEaY_esUPY3OVMrNDI15Ns13xspWS3q-13kdGv9jHI28P87RvMpjz_JCpQ5IM44oSyRnYtVJO-320SB8E2Bw92pmrenbp67KRUzTEVfGU4-obP5RZ09OxvCr1io4KJvEOjDJuuoClF66AT72WymtoMdwzUmhINjR0XSqK6H0MdWsjw7ysyd_JhmqX5CAaT9Pgi0J8lU_pcl215oANqjy7Ob-VMhug9eGyxAWVfu_1u6QJKePlE-w',
+                        'e' => 'AQAB',
+                    ],
+                ],
+                [
+                    "-----BEGIN PUBLIC KEY-----" . PHP_EOL
+                    . "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiGaLqP6y+SJCCBq5Hv6p" . PHP_EOL
+                    . "GDbG/SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInq" . PHP_EOL
+                    . "UvjJur++hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPyg" . PHP_EOL
+                    . "jLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk+ILjv1bORSRl" . PHP_EOL
+                    . "8AK677+1T8isGfHKXGZ/ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl" . PHP_EOL
+                    . "4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw+zHL" . PHP_EOL
+                    . "wQIDAQAB" . PHP_EOL
+                    . "-----END PUBLIC KEY-----",
+                    "-----BEGIN PUBLIC KEY-----" . PHP_EOL
+                    . "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4dGQ7bQK8LgILOdLsYzf" . PHP_EOL
+                    . "ZjkEAoQeVC/aqyc8GC6RX7dq/KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdD" . PHP_EOL
+                    . "Nq1n52TpxQwI2EqxSk7I9fKPKhRt4F8+2yETlYvye+2s6NeWJim0KBtOVrk0gWvE" . PHP_EOL
+                    . " Dgd6WOqJl/yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X+Tip84wqwyRpU" . PHP_EOL
+                    . "lq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll+p/Dg8vAXxJLIJ4SNLcqgFeZe" . PHP_EOL
+                    . "4OfHLgdzMvxXZJnPp/VgmkcpUdRotazKZumj6dBPcXI/XID4Z4Z3OM1KrZPJNdUh" . PHP_EOL
+                    . "xwIDAQAB" . PHP_EOL
+                    . "-----END PUBLIC KEY-----",
+                    "-----BEGIN PUBLIC KEY-----" . PHP_EOL
+                    . "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlxrwmuYSAsTfn+lUu4go" . PHP_EOL
+                    . "ZSXBD9ackM9OJuwUVQHmbZo6GW4Fu/auUdN5zI7Y1dEDfgt7m7QXWbHuMD01HLnD" . PHP_EOL
+                    . "4eRtY+RNwCWdjNfEaY/esUPY3OVMrNDI15Ns13xspWS3q+13kdGv9jHI28P87RvM" . PHP_EOL
+                    . "pjz/JCpQ5IM44oSyRnYtVJO+320SB8E2Bw92pmrenbp67KRUzTEVfGU4+obP5RZ0" . PHP_EOL
+                    . "9OxvCr1io4KJvEOjDJuuoClF66AT72WymtoMdwzUmhINjR0XSqK6H0MdWsjw7ysy" . PHP_EOL
+                    . "d/JhmqX5CAaT9Pgi0J8lU/pcl215oANqjy7Ob+VMhug9eGyxAWVfu/1u6QJKePlE" . PHP_EOL
+                    . "+wIDAQAB" . PHP_EOL
+                    . "-----END PUBLIC KEY-----"
+                ]
+            ]
+        ];
+    }
+
     /** @dataProvider provideToPem */
     public function testToPem($jwk, $expected)
     {


### PR DESCRIPTION
This PR introduces a new convenience method that converts an array of JWKs to PEM, called `multipleToPem`.

Here's a quick look at how it works:
```php
use CoderCat\JWKToPEM\JWKConverter;

// Retrieve Apple's public keys in JWK format
$appleKeys = json_decode(file_get_contents('https://appleid.apple.com/auth/keys'), true);

// Convert the keys to PEM
$converter = new JWKConverter();
$pems = $converter->multipleToPem($appleKeys['keys']);

// $pems is now an array of (string) PEMs
```